### PR TITLE
Allow in offline apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ For more information on contributing to this repository visit [Contributing to a
 - Insert the widget in a page
 - Configure the properties
 
+## Usage in offline apps
+This widget can be used in offline apps. This is useful when anonymous access is enabled, offline synchronization is only enabled after login with a named user.
+
+Note that forgot password functionality cannot be used for offline apps as this requires a microflow call.
+
 ## Properties
 
 ### Display

--- a/src/LoginForm/LoginForm.xml
+++ b/src/LoginForm/LoginForm.xml
@@ -1,4 +1,4 @@
-<widget id="LoginForm.widget.LoginForm" needsEntityContext="false"
+<widget id="LoginForm.widget.LoginForm" needsEntityContext="false" offlineCapable="true" 
         xmlns="http://www.mendix.com/widget/1.0/"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.mendix.com/widget/1.0/ ../../xsd/widget.xsd">


### PR DESCRIPTION
This widget works just fine in offline apps, for the part that works without microflow calls.

I needed it because we need the forgot password functionality and have an offline app.

I changed the offline flag in the XML and added a paragraph to the documentation for offline usage.